### PR TITLE
Small Fix

### DIFF
--- a/nessusToExcel.py
+++ b/nessusToExcel.py
@@ -1174,11 +1174,10 @@ def GenerateHostDictionary():
 # -------------------------------------------------------------------------------
 # Excel Functions -  First create our Excel workbook
 def CreateWorkBook(workBookName):
-    excelPath = os.getcwd() + os.sep + workBookName
-    workbook = xlsxwriter.Workbook(excelPath)
+    workbook = xlsxwriter.Workbook(workBookName)
     
     if args.verbose:
-        print(f'DEBUG - Using Excel output file: {excelPath}')
+        print(f'DEBUG - Using Excel output file: {workBookName}')
     
     return workbook
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nessus_file_reader==0.3.0
-XlsxWriter==3.0.3
+nessus_file_reader
+XlsxWriter


### PR DESCRIPTION
The Excel output file was broken. It was sanitised at first and the modified again within CreateWorkBook()

```
$ python3 nessusToExcel.py --file /mnt/c/Users/XXXX/NotGonnaTellYou/NessusFiles/aaaa.nessus -v
DEBUG - Arguments provided: Namespace(file='/mnt/c/Users/XXXX/NotGonnaTellYou/NessusFiles/aaaa.nessus', verbose=True, out=None, quiet=False, keyword=None, module='all')
DEBUG - No output filename given, new value: /mnt/c/Users/XXXX/NotGonnaTellYou/NessusFiles/aaaa.xlsx
WARN - Host Information.txt is about to be overwritten, would you like to continue? [Y/n] y
DEBUG - Using Excel output file: /mnt/c/Tools/helper-scripts//mnt/c/Users/XXXX/NotGonnaTellYou/NessusFiles/aaaa.xlsx
```

The last DEBUG line shows the broken path ` /mnt/c/Tools/helper-scripts//mnt/c/Users/XXXX/NotGonnaTellYou/NessusFiles/aaaa.xlsx`

____

About the requirements, not sure which was breaking cause as soon as I updated it everything worked. It might have been `XlsxWriter`. I think it is not breaking anymore, I tried with various nessus files, some with CIS, some with everything, etc.

```
Traceback (most recent call last):
  File "/mnt/c/Tools/helper-scripts/nessusToExcel.py", line 1345, in <module>
    extractAll()
  File "/mnt/c/Tools/helper-scripts/nessusToExcel.py", line 49, in extractAll
    extractHTTPServers()
  File "/mnt/c/Tools/helper-scripts/nessusToExcel.py", line 447, in extractHTTPServers
    tableData.append((report_fqdn,report_ip,http_protocol,http_port,lines[2]))
IndexError: list index out of range
```